### PR TITLE
remove transparent option from urxvt so it can be truly transparent.

### DIFF
--- a/.xmonad/xmonad.hs
+++ b/.xmonad/xmonad.hs
@@ -136,7 +136,7 @@ myFocusFollowsMouse = True
 -- The preferred terminal program, which is used in a binding below and by
 -- certain contrib modules.
 myTerminal = "urxvt"
-myTerminal2 = "urxvt --transparent --shading 40 -geometry 100x40"
+myTerminal2 = "urxvt -geometry 100x40"
 -- myTerminal2 = "alacritty"
 myShell = "zsh"
 emacsn = "emacsn"


### PR DESCRIPTION
xmonad was calling urxvt with -transparent which ironically prevents urxvt from being properly transparent. All is working now, in combination with the dotfils PR.